### PR TITLE
add support for django 1.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from djangocms_column import __version__
 
 INSTALL_REQUIRES = [
     'django-cms>=3.2.0',
-    'django>=1.8,<1.10',
+    'django>=1.8,<1.10.999',
 ]
 
 CLASSIFIERS = [


### PR DESCRIPTION
djangocms 3.4 suppports django 1.10, hence modified setuptools requirements