### PR TITLE
Django CMS 3.7 compatability

### DIFF
--- a/djangocms_column/models.py
+++ b/djangocms_column/models.py
@@ -1,9 +1,9 @@
 from django.conf import settings
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from cms.models import CMSPlugin
-from cms.utils.compat.dj import python_2_unicode_compatible
 
 if hasattr(settings, "COLUMN_WIDTH_CHOICES"):
     WIDTH_CHOICES = settings.COLUMN_WIDTH_CHOICES


### PR DESCRIPTION
Changed to import python_2_unicode_compatible directly since it was removed from djangocms as of 3.7